### PR TITLE
Update .gitignore for _config.html location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ venv.bak/
 webapp/config.py
 tests
 user-data
-home/templates/_config.html
+webapp/auth/templates/_config.html
 ezeml/templates/
 **/ezeml-290315-ce4543f85534.json
 webapp/static/unitsWithQUDTInfo.csv


### PR DESCRIPTION
Update `.gitignore` to include the new path for `_config.html` at `webapp/auth/templates`.

This file is generated from a template and was previously ignored in a different location. This prevents accidentally committing instance-specific configuration to the repository.